### PR TITLE
prevent log disappearing on whitespace changes

### DIFF
--- a/js/app-browserify.js
+++ b/js/app-browserify.js
@@ -254,11 +254,11 @@ const analyze = (program) => {
 
         channels.codeAnalyzed.send(code)
         channels.errorOccurred.send()
-        channels.codeCleared.send()
     } catch(e){
         let {stackFrame, message} = e,
             x = {stackFrame, message}
 
+        channels.codeCleared.send()
         channels.errorOccurred.send(x)
     }
     oldProgram = program.trim()

--- a/js/app-browserify.js
+++ b/js/app-browserify.js
@@ -245,9 +245,7 @@ ${code}
 const iframe_code = m.prop(''),
     iframe_el = m.prop()
 
-let oldProgram = null
 const analyze = (program) => {
-    if(oldProgram === program.trim()) return
     try{
         const result = Babel.transform(prefix_code(program), {stage: 1}),
               {code} = result
@@ -261,8 +259,7 @@ const analyze = (program) => {
         channels.codeCleared.send()
         channels.errorOccurred.send(x)
     }
-    oldProgram = program.trim()
-    window.location.hash = `#${escape(oldProgram)}`
+    window.location.hash = `#${escape(program.trim())}`
 }
 
 channels.codeEdited.to(analyze)


### PR DESCRIPTION
to reproduce this tricky bug:

1. http://matthiasak.github.io/arbiter-frame/dist/#log%281%29%0A%0Alog%282%29
1. Insert a newline at line 2
1. Log window disappears

some whitespace changes don't result in changed analyzed code, meaning:
    - iframe URL's hash won't change
    - re-evaluation won't happen
    - log won't be repopulated

fix this by clearing the log before eval, not right after analysis. clear log if analysis fails though