### PR TITLE
range function -  uneven distribution fix

### DIFF
--- a/js/app-browserify.js
+++ b/js/app-browserify.js
@@ -216,7 +216,7 @@ const _log = (arg) => {
 }
 
 const range = (min, max) =>
-    min + Math.round(Math.random() * (max-min))
+    min + Math.floor(Math.random() * (max - min + 1))
 
 const reset = () => window.parent.reset()
 


### PR DESCRIPTION
max and min currently have half the chance of being rolled as any other
number in the range
![rangejs](https://cloud.githubusercontent.com/assets/3784447/12174124/67115570-b520-11e5-9afd-ee7024c59271.PNG)